### PR TITLE
Add `XQueryKeymap` command

### DIFF
--- a/examples/smoketest/querykeymap.js
+++ b/examples/smoketest/querykeymap.js
@@ -1,0 +1,11 @@
+var x11 = require('../../lib');
+
+x11.createClient(function(err, display) {
+    var X = display.client;
+
+    X.QueryKeymap(function query(err, keys) {
+        console.log(keys);
+
+        X.QueryKeymap(query);
+    });
+});

--- a/lib/corereqs.js
+++ b/lib/corereqs.js
@@ -646,6 +646,13 @@ var templates = {
        }
    ],
 
+   QueryKeymap: [
+       ['CxS', [44, 1] ],
+       function(buf) {
+           return buf;
+       }
+   ],
+
    TranslateCoordinates: [
        function(srcWid, dstWid, srcX, srcY) {
            return [ 'CxSLLSS', [ 40, 4, srcWid, dstWid, srcX, srcY ] ];


### PR DESCRIPTION
This PR is a local version of https://github.com/sidorares/node-x11/pull/209.

This enables global tracking of key presses (independent of window focus) that makes implementing applications relating to keylogging possible, such as for the functionality seen with the [screenkey](https://gitlab.com/screenkey/screenkey) application.

This command will be used in the [gShell desktop environment](https://github.com/LiveGTech/gShell) to bind global shortcuts.